### PR TITLE
feat(sql): add PostgreSQL solution for confirmation rate

### DIFF
--- a/2087-confirmation-rate/postgresql-confirmation-rate.sql
+++ b/2087-confirmation-rate/postgresql-confirmation-rate.sql
@@ -1,1 +1,15 @@
 -- TODO: PostgreSQL solution
+
+SELECT s.user_id,
+    ROUND(
+        COALESCE(
+            AVG(
+                CASE WHEN c.action = 'confirmed' 
+                THEN 1 ELSE 0 END
+            ), 0
+        ), 2
+    ) AS confirmation_rate
+FROM Signups s
+LEFT JOIN Confirmations c
+    USING( user_id )
+GROUP BY s.user_id;


### PR DESCRIPTION
Implemented a SQL query to calculate the confirmation rate per user by joining the Signups and Confirmations tables and averaging confirmed actions.